### PR TITLE
Keep navbar closed on new page navigation

### DIFF
--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -1,6 +1,7 @@
 "use client";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
+import { getPathname, usePathname } from "../i18n/navigation";
 import LangSwitcher from "./LangSwitcher";
 
 import Link from "next/link";
@@ -15,13 +16,18 @@ export default function Navbar() {
     setNavOpen(!navOpen);
   };
 
+  let pathname = usePathname();
+
+  useEffect(() => {
+    if (navOpen) {
+      setNavOpen(!navOpen);
+    }
+  }, [pathname]);
+
   return (
     <div>
       <div className="topBar">
         <LangSwitcher />
-        {/* <Link href="/" className="topBarLinks">
-          EN
-        </Link> */}
         {/* <Link href="/" className="topBarLinks">
           {t("Login")}
         </Link> */}

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -10,22 +10,23 @@ export default function middleWareHandler(req) {
 
 export const config = {
   matcher: ["/((?!api|_next|_vercel|.*\\..*).*)"],
-  // matcher: ["/((?!api|_next|_vercel|.*\\..*).*)"],
-  // matcher: ["/", "/(fr|en)/:path*"],
-  // };
-
-  // matcher: [
-  // Enable a redirect to a matching locale at the root
-  // "/",
-
-  // Set a cookie to remember the previous locale for
-  // all requests that have a locale prefix
-  // "/(fr|en)/:path*",
-
-  // Enable redirects that add missing locales
-  // (e.g. `/pathnames` -> `/en/pathnames`)
-  // "/((?!_next|_vercel|.*\\..*).*)",
-
-  // "/((?!api|_next|_vercel|.*\\..*).*)",
-  // ],
 };
+// matcher: ["/((?!api|_next|_vercel|.*\\..*).*)"],
+// matcher: ["/", "/(fr|en)/:path*"],
+// };
+
+// matcher: [
+// Enable a redirect to a matching locale at the root
+// "/",
+
+// Set a cookie to remember the previous locale for
+// all requests that have a locale prefix
+// "/(fr|en)/:path*",
+
+// Enable redirects that add missing locales
+// (e.g. `/pathnames` -> `/en/pathnames`)
+// "/((?!_next|_vercel|.*\\..*).*)",
+
+// "/((?!api|_next|_vercel|.*\\..*).*)",
+// ],
+// };


### PR DESCRIPTION
Added hook so that navbar is closed when clicking to a new page in mobile view (used to always stay open)