### PR TITLE
Contact Form: switch to Brevo service

### DIFF
--- a/locales/en/Contact.json
+++ b/locales/en/Contact.json
@@ -16,5 +16,8 @@
   "Phone": "Phone number",
   "PWError": "Check password",
   "Send": "Send",
-  "Subject": "Subject"
+  "Subject": "Subject",
+  "NetworkError": "Network error. Failed to process request",
+  "SiteError": "Site error. Failed to send message",
+  "CaptchaError": "Captcha Error. Refresh the page"
 }

--- a/locales/fr/Contact.json
+++ b/locales/fr/Contact.json
@@ -16,5 +16,8 @@
   "Phone": "Numéro de téléphone",
   "PWError": "Vérifier le mot de passe",
   "Send": "Envoyer",
-  "Subject": "Sujet"
+  "Subject": "Sujet",
+  "NetworkError": "Erreur de réseau. Échec du traitement de la requête",
+  "SiteError": "Erreur du site. Échec de l'envoi du message",
+  "CaptchaError": "Erreur de Captcha. Veuillez rafraîchir la page"
 }


### PR DESCRIPTION
Add trans points for error messages;
Simplify fetch response, set appropriate messages for front-end; 
Modify route.js to format contact message data to use Brevo as email server instead of web3forms - no costs; Add api keys for Brevo api and hCaptcha api;
Set up email template in Brevo:  name, email and message gets dynamically inserted from api call from front-end, Brevo then sends this out as email to tkd.ccs.adm@gmail.com; 
Add captcha verification in route.js - doesn't get verified like Supabase, so needs verification with hcaptcha server;